### PR TITLE
feat: Enable optional MongoDB connection

### DIFF
--- a/backend/user-service/src/server.js
+++ b/backend/user-service/src/server.js
@@ -6,6 +6,7 @@ const { mongoConnect } = require('./services/mongo');
 const logger = require('./utils/logger'); // Import the logger module
 
 const PORT = process.env.PORT || 8000;
+const CONNECT_TO_DB = process.env.CONNECT_TO_DB === 'true';
 
 const server = http.createServer(app);
 
@@ -20,7 +21,13 @@ const server = http.createServer(app);
 // - Retry capability: It's easier to implement retries for database connection in case of failure.
 async function startServer() {
   try {
-    await mongoConnect();  
+    if (CONNECT_TO_DB) {
+      await mongoConnect();
+      logger.info('Connected to MongoDB');
+    } else {
+      logger.info('Not connecting to MongoDB');
+    }
+
     server.listen(PORT, () => {
       logger.info(`Listening on port ${PORT}...`); // Use the logger module
     });


### PR DESCRIPTION
feat: Enable optional MongoDB connection

This pull request enables optional MongoDB connection for the user-service. The server can now be started without a MongoDB connection, which is useful for testing and development.

This change is needed to allow developers to run the user-service without a MongoDB instance, which simplifies local development and testing.

I added a `CONNECT_TO_DB` environment variable to control whether the server connects to MongoDB. The `mongoConnect` function is only called if `CONNECT_TO_DB` is set to `true`.

This change does not introduce any known side effects.

I tested the server with `CONNECT_TO_DB=true` and `CONNECT_TO_DB=false` to ensure that it connects to MongoDB when the variable is set to `true` and does not connect when it is set to `false`.

Please review the code carefully, especially the conditional logic in `server.js`.